### PR TITLE
Implement data-task API (NSURLSessionDataTask)

### DIFF
--- a/apidoc/Session.yml
+++ b/apidoc/Session.yml
@@ -59,7 +59,27 @@ methods:
     parameters:
       - name: args
         summary: An object representing the arguments to add a new upload task.
-        type: UploadTaskType
+        type: UploadDataTaskType
+    returns:
+        summary: Task's identifier number.
+        type: String 
+ 
+  - name: dataTask
+    summary: |
+        Creates a data task for the specified URL, within the provided session 
+        object and local data.
+    description: |
+        An data task does not provide any additional functionality over a usual
+        session task and its presence is merely to provide lexical differentiation 
+        from download and upload tasks.
+        
+        Once this function is called, the task starts automatically. Once finished,
+        the data task will call the `sessioncompleted` event containing infos about
+        the response.
+    parameters:
+      - name: args
+        summary: An object representing the arguments to add a new task task.
+        type: UploadDataTaskType
     returns:
         summary: Task's identifier number.
         type: String          
@@ -107,7 +127,7 @@ properties:
     type: String
 
 ---
-name: UploadTaskType
+name: UploadDataTaskType
 summary: The parameter for [uploadTask](Modules.URLSession.Session.uploadTask) method.
 properties:
   - name: url

--- a/ios/Classes/ComAppceleratorUrlSessionSessionProxy.h
+++ b/ios/Classes/ComAppceleratorUrlSessionSessionProxy.h
@@ -25,6 +25,8 @@
 
 - (id)downloadTask:(id)args;
 
+- (id)dataTask:(id)args;
+
 - (void)finishTasksAndInvalidate:(id)unused;
 
 - (void)invalidateAndCancel:(id)unused;

--- a/ios/Classes/ComAppceleratorUrlSessionSessionProxy.m
+++ b/ios/Classes/ComAppceleratorUrlSessionSessionProxy.m
@@ -47,7 +47,7 @@
     NSString *method = nil;
     NSURL *fileURL = nil;
     NSDictionary *headers = nil;
-    id data = [args objectForKey:@"data"];;
+    id data = [args objectForKey:@"data"];
     
     ENSURE_ARG_FOR_KEY(url, args, @"url", NSString);
     ENSURE_ARG_OR_NIL_FOR_KEY(method, args, @"method", NSString);
@@ -116,7 +116,7 @@
   NSString *url = nil;
   NSString *method = nil;
   NSDictionary *headers = nil;
-  id data = [args objectForKey:@"data"];;
+  id data = [args objectForKey:@"data"];
   
   ENSURE_ARG_FOR_KEY(url, args, @"url", NSString);
   ENSURE_ARG_OR_NIL_FOR_KEY(method, args, @"method", NSString);

--- a/ios/manifest
+++ b/ios/manifest
@@ -2,7 +2,7 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 2.1.0
+version: 2.2.0
 apiversion: 2
 architectures: armv7 arm64 i386 x86_64
 description: ti.urlsession


### PR DESCRIPTION
Prerelease: [com.appcelerator.urlSession-iphone-2.2.0.zip](https://github.com/appcelerator-modules/ti.urlsession/files/1543438/com.appcelerator.urlSession-iphone-2.2.0.zip)

Example usage:
```js
var URLSession = require('com.appcelerator.urlSession');

var sessionConfig = URLSession.createSessionConfiguration({
  identifier: 'com.test.test2'
});

var session = URLSession.createSession({
  configuration: sessionConfig
}); 

var taskIdentifier = session.dataTask({
  url: 'http://some-url.io',
  type: "POST",
  requestHeaders: {
    'Content-Type': 'application/json'
  },
  data: {
    id: 123,
    category: "category-456"
  }
});
```