### PR TITLE
Exposing downloadTaskWithRequst

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ to `downloadprogress` , `downloadcompleted`, `sessioneventscompleted` and `sessi
   * url (String): The remote url used for this data task.
 
 
-#### downloadTaskWithWithRequest(arguments)
+#### downloadTaskWithRequest(arguments)
 Creates a download task for the specified URL, within the provided session object and saves the results to a file.
 This method extends the downloadTask function to allow data to be downloaded as part of a POST request.
 Once this function is called, the download starts automatically. The progress of the download can be monitored by listening 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,20 @@ to `downloadprogress` , `downloadcompleted`, `sessioneventscompleted` and `sessi
 * Takes an object of one argument:
   * url (String): The remote url used for this data task.
 
+
+#### downloadTaskWithWithRequest(arguments)
+Creates a download task for the specified URL, within the provided session object and saves the results to a file.
+This method extends the downloadTask function to allow data to be downloaded as part of a POST request.
+Once this function is called, the download starts automatically. The progress of the download can be monitored by listening 
+to `downloadprogress` , `downloadcompleted`, `sessioneventscompleted` and `sessioncompleted` events explained below.
+
+* Takes an object of arguments:
+  * url (String): The remote url used for this data task.
+  * data (TiBlob): The data blob provided for this download task.
+  * method (String): The request method (e.g. POST or PUT). Default: POST.
+  * requestHeaders (Array<String: String>): Additional request headers to pass to the request.
+
+
 #### uploadTask(arguments)
 
 Creates an upload task for the specified URL, within the provided session object and the file-blob to upload.

--- a/ios/Classes/ComAppceleratorUrlSessionSessionProxy.h
+++ b/ios/Classes/ComAppceleratorUrlSessionSessionProxy.h
@@ -25,6 +25,8 @@
 
 - (id)downloadTask:(id)args;
 
+- (id)downloadTaskWithRequest:(id)args;
+
 - (id)dataTask:(id)args;
 
 - (void)finishTasksAndInvalidate:(id)unused;

--- a/ios/Classes/ComAppceleratorUrlSessionSessionProxy.m
+++ b/ios/Classes/ComAppceleratorUrlSessionSessionProxy.m
@@ -6,6 +6,7 @@
  */
 
 #import "ComAppceleratorUrlSessionSessionProxy.h"
+#import "TiBlob.h"
 
 @implementation ComAppceleratorUrlSessionSessionProxy
 
@@ -107,6 +108,47 @@
   return nil;
 }
 
+- (id)downloadTaskWithRequest:(id)args
+{
+  ENSURE_SINGLE_ARG(args, NSDictionary);
+  
+    NSString *url = nil;
+    NSString *method = nil;
+    NSDictionary *headers = nil;
+    id data = [args objectForKey:@"data"];
+    
+    ENSURE_ARG_FOR_KEY(url, args, @"url", NSString);
+    ENSURE_ARG_OR_NIL_FOR_KEY(method, args, @"method", NSString);
+    ENSURE_ARG_OR_NIL_FOR_KEY(headers, args, @"requestHeaders", NSDictionary);
+    
+  NSURL *nativeURL = [TiUtils toURL:url proxy:self];
+
+  if (nativeURL == nil) {
+    NSLog(@"[ERROR] Ti.URLSession: The specified URL for this download task is empty. Please provide a valid URL.");
+    return nil;
+  }
+    
+    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:nativeURL];
+    
+    // HTTP method
+    [request setHTTPMethod:(method ?: @"POST")];
+    
+    if (data != nil) {
+      NSError *error = nil;
+      NSData *postData = [NSJSONSerialization dataWithJSONObject:data options:0 error:&error];
+      
+      if (error == nil) {
+        [request setHTTPBody:postData];
+      } else {
+        DebugLog(@"[ERROR] Could not append data: %@", error.localizedDescription);
+      }
+    }
+  
+    NSURLSessionDownloadTask *task = [_session downloadTaskWithRequest:request];
+    [task resume];
+    
+  return NUMINTEGER([task taskIdentifier]);
+}
 
 - (id)dataTask:(id)args
 {


### PR DESCRIPTION
Exposing downloadTaskWithRequst to allow use of POST requests to download files.

The use case is to enable file downloads from API endpoints that require some data or headers to be sent in, for security purposes or otherwise.
